### PR TITLE
Removing option for multiple spaces after EXPOSE

### DIFF
--- a/syntaxes/earthfile.tmLanguage.json
+++ b/syntaxes/earthfile.tmLanguage.json
@@ -71,7 +71,7 @@
 					"name": "constant.character.escape.earthfile"
 				},
 				{
-					"match": "(?<=EXPOSE\\s+)(\\d+)",
+					"match": "(?<=EXPOSE\\s)(\\d+)",
 					"name": "constant.numeric.earthfile"
 				}
 			]


### PR DESCRIPTION
Context: I know this `+` has been recently added in https://github.com/earthly/earthfile-grammar/commit/709d0cf5192f274b228ee64943cb200bb4988be5 / https://github.com/earthly/earthly/pull/1196
but it doesn't work with the tool Github uses for grammars - i.e. linguist/grammar-compiler

The error thrown there is:
```
- Invalid regex in grammar: `source.earthfile` (in `syntaxes/earthfile.tmLanguage.json`) contains a malformed regex (regex "`(?<=EXPOSE\s+)(\d+)`": lookbehind assertion is not fixed length (at offset 13))
```

I suggest to proceed with this PR, if Github support for Earthfiles (https://github.com/earthly/earthly/issues/1292) is more important that the bug fixed there. And maybe we can have another fix for that problem.
